### PR TITLE
Fix "must be of the type string, null given" issue

### DIFF
--- a/classes/class.ilMDViewerPluginGUI.php
+++ b/classes/class.ilMDViewerPluginGUI.php
@@ -119,7 +119,7 @@ class ilMDViewerPluginGUI extends ilPageComponentPluginGUI
             $link_prefix;
 
         $external_content_raw = @file_get_contents($external_file);
-        if ($this->areFilterBlocksEnabled() && '' !== $this->stripWhitespaces($a_properties[self::F_BLOCKS_FILTER])) {
+        if ($this->areFilterBlocksEnabled() && '' !== $this->stripWhitespaces($a_properties[self::F_BLOCKS_FILTER] ?? '')) {
             $external_content_raw = $this->filterRawContentString(
                 $external_content_raw,
                 explode(',', $a_properties[self::F_BLOCKS_FILTER])


### PR DESCRIPTION
An issue appeared, which was easy to fix (in my opinion). Please merge or fix, as you please.

```
TypeError thrown with message "Argument 1 passed to ilMDViewerPluginGUI::stripWhitespaces() must be of the type string, null given, called in ./Customizing/global/plugins/Services/COPage/PageComponent/MDViewer/classes/class.ilMDViewerPluginGUI.php on line 122"

Stacktrace:
#12 TypeError in ./Customizing/global/plugins/Services/COPage/PageComponent/MDViewer/classes/class.ilMDViewerPluginGUI.php:300
#11 ilMDViewerPluginGUI:stripWhitespaces in ./Customizing/global/plugins/Services/COPage/PageComponent/MDViewer/classes/class.ilMDViewerPluginGUI.php:122
#10 ilMDViewerPluginGUI:getElementHTML in ./Services/COPage/classes/class.ilPCPlugged.php:325
#9 ilPCPlugged:modifyPageContentPostXsl in ./Services/COPage/classes/class.ilPageObjectGUI.php:1659
#8 ilPageObjectGUI:showPage in ./Services/COPage/classes/class.ilPageObjectGUI.php:2458
#7 ilPageObjectGUI:presentation in ./Modules/LearningModule/Presentation/class.ilLMContentRendererGUI.php:277
#6 ilLMContentRendererGUI:render in./Modules/LearningModule/Presentation/class.ilLMPresentationGUI.php:1157
```