### PR TITLE
FIX 'Undefined array key "link_prefix_url"'

### DIFF
--- a/classes/class.ilMDViewerPluginGUI.php
+++ b/classes/class.ilMDViewerPluginGUI.php
@@ -114,7 +114,7 @@ class ilMDViewerPluginGUI extends ilPageComponentPluginGUI
         /** @var $template ilTemplate */
         $template = $this->getPlugin()->getTemplate('tpl.output.html', true, true);
         $external_file = $a_properties[self::F_EXTERNAL_MD];
-        $link_prefix = $a_properties[self::F_LINK_PREFIX];
+        $link_prefix = $a_properties[self::F_LINK_PREFIX] ?? '';
         $link_prefix = ('' === $link_prefix) ?
             rtrim(dirname($external_file), "/") . "/" :
             $link_prefix;


### PR DESCRIPTION
Whoops\Exception\ErrorException thrown with message "Undefined array key "link_prefix_url""

Stacktrace:
#12 Whoops\Exception\ErrorException in /srv/www/docu.ilias.de/html/ilias/Customizing/global/plugins/Services/COPage/PageComponent/MDViewer/classes/class.ilMDViewerPluginGUI.php:117 #11 ilErrorHandling:handlePreWhoops in /srv/www/docu.ilias.de/html/ilias/Customizing/global/plugins/Services/COPage/PageComponent/MDViewer/classes/class.ilMDViewerPluginGUI.php:117 #10 ilMDViewerPluginGUI:getElementHTML in /srv/www/docu.ilias.de/html/ilias/Services/COPage/PC/Plugged/class.ilPCPlugged.php:324 #9 ilPCPlugged:modifyPageContentPostXsl in /srv/www/docu.ilias.de/html/ilias/Services/COPage/classes/class.ilPageObjectGUI.php:1624 #8 ilPageObjectGUI:showPage in /srv/www/docu.ilias.de/html/ilias/Services/COPage/classes/class.ilPageObjectGUI.php:2522 #7 ilPageObjectGUI:presentation in /srv/www/docu.ilias.de/html/ilias/Modules/LearningModule/Presentation/class.ilLMContentRendererGUI.php:276 #6 ilLMContentRendererGUI:render in /srv/www/docu.ilias.de/html/ilias/Modules/LearningModule/Presentation/class.ilLMPresentationGUI.php:1154 root@apollon:/srv/www/docu.ilias.de/admin# vim /srv/www/docu.ilias.de/html/ilias/Customizing/global/plugins/Services/COPage/PageComponent/MDViewer/classes/class.ilMDViewerPluginGUI.php